### PR TITLE
Add per-API version code and ABI_FILTER parameter

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,11 @@ android {
         abi {
             enable true
             reset()
-            include 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
+            if (project.hasProperty("ABI_FILTER")) {
+                include(ABI_FILTER)
+            } else {
+                include 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
+            }
             universalApk false
         }
     }
@@ -50,8 +54,8 @@ android {
         applicationId "com.moi.lumine"
         minSdk 24
         targetSdk 36
-        versionCode 1
-        versionName "1.0"
+        versionCode 13
+        versionName "0.1.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -86,6 +90,17 @@ android {
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
+        }
+    }
+}
+
+ext.abiCodes = [ "arm64-v8a": 1, "armeabi-v7a": 2, "x86": 3, "x86_64": 4 ]
+import com.android.build.OutputFile
+android.applicationVariants.all { variant ->
+    variant.outputs.each { output ->
+        def abiVersionCode = project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
+        if (abiVersionCode != null) {
+            output.versionCodeOverride = variant.versionCode * 10 + abiVersionCode
         }
     }
 }


### PR DESCRIPTION
Continue preparing for #1.

1. `ABI_FILTER` parameter allows fdroidserver to build APK for a specified ABI target. 
2. Per-ABI version code is necessary for auto update to work.
3. Updated versionName and versionCode, don't forget to update them at next Git tag release, too.