### PR TITLE
Disable DependencyInfoBlock

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,6 +92,12 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle false
+    }
 }
 
 ext.abiCodes = [ "armeabi-v7a": 1, "arm64-v8a": 2, "x86": 3, "x86_64": 4 ]


### PR DESCRIPTION
F-Droid scanner finds that there is a `DependencyInfoBlock` in our APK.

It's a [Signing block](https://source.android.com/docs/security/features/apksigning/v2#apk-signing-block) added by AGP and encrypted with the Google public key so it can't be read by anyone else except Google. You can read more about it [here](https://gitlab.com/fdroid/admin/-/issues/367) and [here](https://gitlab.com/fdroid/fdroidserver/-/issues/1056).

While this was added a while ago, F-Droid were only enforcing it for new apps, and recently they started scanning updates too.

I have disabled it with the following code.

```
android {
    dependenciesInfo {
        // Disables dependency metadata when building APKs.
        includeInApk false
        // Disables dependency metadata when building Android App Bundles.
        includeInBundle false
    }
}
```

I'll need a new release with this fix.