### PR TITLE
Fix concurrency issues in tcpDialID and udpDialID by using CAS spin

### DIFF
--- a/enimul/internal/core/counter.go
+++ b/enimul/internal/core/counter.go
@@ -1,0 +1,20 @@
+package core
+
+import "sync/atomic"
+
+type Counter struct {
+	v atomic.Uint32
+}
+
+func (c *Counter) Next() uint32 {
+again:
+	old := c.v.Load()
+	new := old + 1
+	if new > maxConnID {
+		new = 1
+	}
+	if c.v.CompareAndSwap(old, new) {
+		return new
+	}
+	goto again
+}

--- a/enimul/internal/core/http.go
+++ b/enimul/internal/core/http.go
@@ -7,7 +7,6 @@ import (
 	"maps"
 	"net"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/lzpls/enimul/internal/dial"
@@ -21,20 +20,7 @@ const (
 	status502 = "502 Bad Gateway"
 )
 
-var (
-	httpConnID      uint32
-	httpConnIDMutex sync.Mutex
-)
-
-func getHTTPConnID() uint32 {
-	httpConnIDMutex.Lock()
-	defer httpConnIDMutex.Unlock()
-	httpConnID++
-	if httpConnID > maxConnID {
-		httpConnID = 1
-	}
-	return httpConnID
-}
+var httpConnID Counter
 
 func HTTPAccept(addr *string, serverAddr string, stop <-chan struct{}) {
 	var listenAddr string
@@ -75,7 +61,7 @@ func HTTPAccept(addr *string, serverAddr string, stop <-chan struct{}) {
 }
 
 func httpHandler(w http.ResponseWriter, req *http.Request) {
-	logger := newLogger(F.ConnIDToHex5('H', getHTTPConnID()))
+	logger := newLogger(F.ConnIDToHex5('H', httpConnID.Next()))
 	logger.Info(req.RemoteAddr, " - \"", req.Method, " ", req.RequestURI, " ", req.Proto, "\"")
 
 	if req.Method == http.MethodConnect {

--- a/enimul/mobile/lumine_proxy.go
+++ b/enimul/mobile/lumine_proxy.go
@@ -5,22 +5,19 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"sync/atomic"
 	"time"
 
-	"github.com/miekg/dns"
 	lumine "github.com/lzpls/enimul/internal/core"
+	F "github.com/lzpls/enimul/internal/fmt"
 	"github.com/lzpls/enimul/internal/log"
+	"github.com/miekg/dns"
 	"github.com/xjasonlyu/tun2socks/v2/metadata"
 	"github.com/xjasonlyu/tun2socks/v2/proxy/proto"
 )
 
 type LumineProxy struct{}
 
-var (
-	tcpDialID uint32
-	udpDialID uint32
-)
+var tcpDialID, udpDialID lumine.Counter
 
 func (p *LumineProxy) Addr() string {
 	return "lumine"
@@ -36,7 +33,7 @@ func (p *LumineProxy) DialContext(ctx context.Context, m *metadata.Metadata) (ne
 	}
 
 	originHost := m.DstIP.String()
-	logger := lumine.NewSessionLogger(fmt.Sprintf("[T%05x]", nextID(&tcpDialID)))
+	logger := lumine.NewSessionLogger(F.ConnIDToHex5('T', tcpDialID.Next()))
 	if lumine.IsVPNDNSAddress(originHost, int(m.DstPort)) {
 		logger.Debug("Hijacking TCP DNS for", net.JoinHostPort(originHost, fmt.Sprintf("%d", m.DstPort)))
 		return newLocalDNSTCPConn(logger)
@@ -75,7 +72,7 @@ func (p *LumineProxy) DialContext(ctx context.Context, m *metadata.Metadata) (ne
 }
 
 func (p *LumineProxy) DialUDP(m *metadata.Metadata) (net.PacketConn, error) {
-	logger := lumine.NewSessionLogger(fmt.Sprintf("[U%05x]", nextID(&udpDialID)))
+	logger := lumine.NewSessionLogger(F.ConnIDToHex5('U', udpDialID.Next()))
 	if m == nil || !m.DstIP.IsValid() {
 		logger.Error("Invalid UDP metadata:", m)
 		return nil, fmt.Errorf("invalid udp metadata: %+v", m)
@@ -183,15 +180,6 @@ func joinPlanLogMessage(network string, plan lumine.DialPlan, target string) str
 		}
 	}
 	return fmt.Sprintf("%s %s -> %s mode=%s", network, origin, target, plan.Policy.Mode)
-}
-
-func nextID(counter *uint32) uint32 {
-	id := atomic.AddUint32(counter, 1)
-	if id > 0xFFFFF {
-		atomic.StoreUint32(counter, 0)
-		return 0
-	}
-	return id
 }
 
 func summarizeDNSPacket(payload []byte) string {


### PR DESCRIPTION
https://github.com/SniShaper/lumine-for-android/blob/987c781834fdf9282f0132b78c646db4fb242ea3/enimul/mobile/lumine_proxy.go#L188-L195

这照搬了 lumine 的错误写法，ID 超过 0xFFFFF 重置时存在竞态。可以改为 CAS 自旋或者互斥锁，但互斥锁高并发时性能差点，尤其是在 Android 上即使低并发也有很大差距，参见[测试](https://github.com/lzpls/enimul/blob/main/internal/core/counter_test.go)，所以 httpConnID 也换成 CAS。

额外行为变更：
- ID 格式变为 T[00000]、U[00000]
- ID 超过 0xFFFFF 重置为 1 而不是 0，因为初始状态第一个 ID 就是 1