### PR TITLE
Function: Enhanced keep-alive function

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -123,6 +123,9 @@ dependencies {
     implementation 'androidx.compose.material:material-icons-extended'
     implementation 'com.google.android.material:material:1.11.0'
     
+    // Background keep-alive
+    implementation 'androidx.work:work-runtime-ktx:2.9.0'
+    
     // JSON & Networking
     implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
     

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,9 +4,13 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <application
+        android:name=".LumineApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="Lumine"
@@ -28,10 +32,45 @@
             android:name=".LumineVpnService"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:exported="false"
-            android:foregroundServiceType="systemExempted">
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="vpn_proxy_keepalive" />
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>
+        </service>
+
+        <receiver
+            android:name=".keepalive.BootReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".keepalive.ServiceRestartReceiver"
+            android:exported="false" />
+
+        <!-- JobScheduler 保活服务 -->
+        <service
+            android:name=".keepalive.KeepAliveJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false" />
+
+        <!-- 无障碍保活服务 -->
+        <service
+            android:name=".keepalive.KeepAliveAccessibilityService"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config" />
         </service>
 
         <provider

--- a/android/app/src/main/kotlin/com/moi/lumine/LumineApp.kt
+++ b/android/app/src/main/kotlin/com/moi/lumine/LumineApp.kt
@@ -1,0 +1,40 @@
+package com.moi.lumine
+
+import android.app.Application
+import android.util.Log
+import com.moi.lumine.keepalive.KeepAlive
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+class LumineApp : Application() {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun onCreate() {
+        super.onCreate()
+
+        // 开启过代理才保活：调度闹钟/JobScheduler/WorkManager
+        if (KeepAlive.shouldRun(this)) {
+            KeepAlive.scheduleAll(this)
+        }
+
+        startWatchdog()
+    }
+
+    // 进程存活但服务已死 → 拉起（每 10 秒检查，仅代理开启时）
+    private fun startWatchdog() {
+        scope.launch {
+            while (isActive) {
+                delay(10_000L)
+                if (!KeepAlive.shouldRun(this@LumineApp)) continue
+                if (!LumineVpnService.isServiceRunning) {
+                    Log.w("LumineApp", "进程存活但服务已死，拉起代理服务")
+                    KeepAlive.tryRestart(this@LumineApp)
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/moi/lumine/LumineVpnService.kt
+++ b/android/app/src/main/kotlin/com/moi/lumine/LumineVpnService.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.ParcelFileDescriptor
 import android.os.SystemClock
 import android.util.Log
+import com.moi.lumine.keepalive.KeepAlive
 import com.moi.lumine.repository.ConfigRepository
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
@@ -40,6 +41,11 @@ class LumineVpnService : VpnService() {
     @Volatile private var coreStopIssued = false
     @Volatile private var lastWatchdogRecoveryAt = 0L
 
+    override fun onCreate() {
+        super.onCreate()
+        isServiceRunning = true
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val action = intent?.action
         if (action == ACTION_STOP) {
@@ -52,6 +58,17 @@ class LumineVpnService : VpnService() {
         val requestedConfig = intent?.getStringExtra(EXTRA_CONFIG_NAME)?.takeIf { it.isNotBlank() }
         val shouldRecover = requestedConfig == null && repository.shouldVpnBeRunning()
         val targetConfig = requestedConfig ?: if (shouldRecover) repository.getLastRunningConfigName() else null
+
+        // 恢复路径：VPN 授权丢失（划掉重启/系统重置）时，拉起主界面重新授权，
+        // 不要在这里 startVpn()，否则 establish() 抛 SecurityException 会清掉保活标志
+        if (shouldRecover && VpnService.prepare(this) != null) {
+            Log.i("LumineVpn", "VPN permission lost, requesting re-authorization")
+            // startForegroundService 起的服务必须在 5 秒内 startForeground，否则系统杀服务
+            startForeground(NOTIFICATION_ID, buildNotification("等待 VPN 授权"))
+            VpnRuntimeState.setStatus("authorizing", "需要重新授权 VPN 权限")
+            requestVpnPermissionFromUi()
+            return START_STICKY
+        }
 
         if (targetConfig == null) {
             Log.i("LumineVpn", "Ignoring sticky restart without persisted running state")
@@ -71,6 +88,18 @@ class LumineVpnService : VpnService() {
         }
         startVpn()
         return START_STICKY
+    }
+
+    private fun requestVpnPermissionFromUi() {
+        try {
+            val intent = Intent(this, MainActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                putExtra(EXTRA_REQUEST_VPN_PERMISSION, true)
+            }
+            startActivity(intent)
+        } catch (e: Exception) {
+            Log.w("LumineVpn", "无法打开授权页面: ${e.message}")
+        }
     }
 
     private fun startVpn() {
@@ -134,8 +163,9 @@ class LumineVpnService : VpnService() {
                         }
                         val error = Mobile.startLumine(fd.toLong(), configName)
                         if (error.isNotEmpty()) {
+                            // Go 引擎失败时可能已自行关闭 fd，此处绝不 close，避免 fdsan 崩溃；泄漏由进程回收
+                            coreTunFd = null
                             coreOwnsTunFd = false
-                            closePendingTunFd()
                             Log.e("LumineVpn", "Go core failed: $error")
                             updateNotification("启动失败: $error")
                             VpnRuntimeState.setActive(false)
@@ -239,7 +269,26 @@ class LumineVpnService : VpnService() {
         }
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        // 用户要求：划掉后台 → 完全停止服务（停核心 + 移除前台通知，UI/通知状态一致）。
+        // 保活组件（无障碍/闹钟/JobScheduler）随后拉起新实例，recover 路径会重新校验 VPN 授权。
+        if (KeepAlive.shouldRun(this)) {
+            KeepAlive.scheduleAll(this)
+            stopWatchdog()
+            stopLogPump()
+            performCoreShutdownIfNeeded()
+            runCatching {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+            }
+            stopSelf()
+            VpnRuntimeState.setActive(false)
+            VpnRuntimeState.setStatus("idle", "点此启动服务")
+        }
+    }
+
     override fun onDestroy() {
+        isServiceRunning = false
         stopWatchdog()
         stopLogPump()
         performCoreShutdownIfNeeded()
@@ -354,6 +403,8 @@ class LumineVpnService : VpnService() {
     private fun closePendingTunFd() {
         val fd = coreTunFd ?: return
         coreTunFd = null
+        // 仅在 Go 引擎未接管时调用（startLumine 之前）。接管后所有权归 Go 引擎，
+        // 绝不在此 close，否则 fdsan 检测到双重关闭会 SIGABRT 崩溃。
         runCatching { ParcelFileDescriptor.adoptFd(fd).close() }
     }
 
@@ -473,9 +524,13 @@ class LumineVpnService : VpnService() {
     companion object {
         private const val ACTION_STOP = "STOP"
         private const val EXTRA_CONFIG_NAME = "CONFIG_NAME"
+        const val EXTRA_REQUEST_VPN_PERMISSION = "REQUEST_VPN_PERMISSION"
         private const val NOTIFICATION_CHANNEL_ID = "lumine_vpn"
         private const val NOTIFICATION_ID = 1001
         private const val WATCHDOG_INTERVAL_MS = 5_000L
         private const val WATCHDOG_RECOVERY_COOLDOWN_MS = 15_000L
+
+        @Volatile
+        var isServiceRunning = false
     }
 }

--- a/android/app/src/main/kotlin/com/moi/lumine/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/moi/lumine/MainActivity.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.*
 import androidx.navigation.navArgument
+import com.moi.lumine.repository.ConfigRepository
 import com.moi.lumine.ui.ConfigViewModel
 import com.moi.lumine.ui.Screen
 import com.moi.lumine.ui.screens.*
@@ -46,14 +47,17 @@ class MainActivity : ComponentActivity() {
         }
         setContent {
             LumineTheme {
-                MainContainer()
+                MainContainer(
+                    requestVpnPermission = intent
+                        ?.getBooleanExtra(LumineVpnService.EXTRA_REQUEST_VPN_PERMISSION, false) == true
+                )
             }
         }
     }
 }
 
 @Composable
-fun MainContainer() {
+fun MainContainer(requestVpnPermission: Boolean = false) {
     val context = LocalContext.current
     val navController = rememberNavController()
     val viewModel: ConfigViewModel = viewModel()
@@ -80,6 +84,25 @@ fun MainContainer() {
         } else {
             VpnRuntimeState.setStatus("idle", "VPN 权限未授予")
             toggleLocked = false
+        }
+    }
+
+    // 打开应用时自动恢复：带授权请求标记，或保活标记还在但服务已死
+    LaunchedEffect(Unit) {
+        val shouldAutoRecover = requestVpnPermission ||
+            (ConfigRepository(context).shouldVpnBeRunning() && !LumineVpnService.isServiceRunning)
+        if (!shouldAutoRecover) return@LaunchedEffect
+
+        val vpnIntent = VpnService.prepare(context)
+        if (vpnIntent != null) {
+            VpnRuntimeState.setStatus("authorizing", "需要重新授权 VPN 权限")
+            vpnRequestLauncher.launch(vpnIntent)
+        } else {
+            VpnRuntimeState.setStatus("starting", "正在恢复代理")
+            val intent = Intent(context, LumineVpnService::class.java).apply {
+                putExtra("CONFIG_NAME", viewModel.selectedConfigName.value)
+            }
+            ContextCompat.startForegroundService(context, intent)
         }
     }
 
@@ -149,6 +172,9 @@ fun MainContainer() {
             }
             composable(Screen.Settings.route) { GlobalSettingsScreen(navController, viewModel) }
             composable(Screen.Logs.route) { LogScreen(navController, viewModel) }
+            composable(Screen.KeepAlive.route) {
+                com.moi.lumine.keepalive.KeepAliveGuideScreen(navController)
+            }
         }
     }
 }

--- a/android/app/src/main/kotlin/com/moi/lumine/keepalive/BootReceiver.kt
+++ b/android/app/src/main/kotlin/com/moi/lumine/keepalive/BootReceiver.kt
@@ -1,0 +1,29 @@
+package com.moi.lumine.keepalive
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action
+        if (action != Intent.ACTION_BOOT_COMPLETED && action != Intent.ACTION_MY_PACKAGE_REPLACED) return
+
+        // 未开启代理 → 不保活
+        if (!KeepAlive.shouldRun(context)) return
+
+        val pendingResult = goAsync()
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            try {
+                KeepAlive.tryRestart(context)
+                KeepAlive.scheduleAll(context)
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/moi/lumine/keepalive/KeepAlive.kt
+++ b/android/app/src/main/kotlin/com/moi/lumine/keepalive/KeepAlive.kt
@@ -1,0 +1,61 @@
+package com.moi.lumine.keepalive
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.ContextCompat
+import com.moi.lumine.LumineVpnService
+import com.moi.lumine.repository.ConfigRepository
+
+/**
+ * 保活公共入口：所有保活组件（闹钟/JobScheduler/WorkManager/无障碍/开机广播）
+ * 统一通过本类检查状态并拉起 [LumineVpnService]。
+ *
+ * 状态依据：ConfigRepository.vpn_should_run（用户启动过代理即为 true）。
+ * 服务已死但标记还在 → startForegroundService 不带 CONFIG_NAME，
+ * LumineVpnService 会走 recover 路径自动用上次配置恢复。
+ */
+object KeepAlive {
+
+    @Volatile
+    private var repo: ConfigRepository? = null
+
+    private fun repository(context: Context): ConfigRepository {
+        val cached = repo
+        if (cached != null) return cached
+        synchronized(this) {
+            val current = repo
+            if (current != null) return current
+            return ConfigRepository(context.applicationContext).also { repo = it }
+        }
+    }
+
+    fun shouldRun(context: Context): Boolean =
+        repository(context).shouldVpnBeRunning()
+
+    fun tryRestart(context: Context) {
+        if (!shouldRun(context)) return
+        if (LumineVpnService.isServiceRunning) return
+        try {
+            ContextCompat.startForegroundService(
+                context.applicationContext,
+                Intent(context.applicationContext, LumineVpnService::class.java)
+            )
+            Log.d("KeepAlive", "已拉起 Lumine 代理服务")
+        } catch (e: Exception) {
+            Log.w("KeepAlive", "拉起服务失败: ${e.message}")
+        }
+    }
+
+    fun scheduleAll(context: Context) {
+        ServiceRestartReceiver.scheduleAlarm(context)
+        KeepAliveJobService.schedule(context)
+        ServiceWatchdogWorker.schedule(context)
+    }
+
+    fun cancelAll(context: Context) {
+        ServiceRestartReceiver.cancelAlarm(context)
+        KeepAliveJobService.cancel(context)
+        ServiceWatchdogWorker.cancel(context)
+    }
+}

--- a/android/app/src/main/kotlin/com/moi/lumine/keepalive/KeepAliveAccessibilityService.kt
+++ b/android/app/src/main/kotlin/com/moi/lumine/keepalive/KeepAliveAccessibilityService.kt
@@ -1,0 +1,31 @@
+package com.moi.lumine.keepalive
+
+import android.accessibilityservice.AccessibilityService
+import android.util.Log
+import android.view.accessibility.AccessibilityEvent
+
+/**
+ * 无障碍保活服务
+ *
+ * 原理：用户划掉app时，系统会杀主进程，但无障碍服务是系统绑定的，
+ * 系统会立刻重新创建该服务进程，触发 onServiceConnected，
+ * 我们顺势拉起前台代理服务。
+ *
+ * 使用方法：
+ * 1. 手机设置 → 无障碍/辅助功能 → 找到 "Lumine" → 开启
+ * 2. 首次开启时系统会弹窗确认，点击允许即可
+ */
+class KeepAliveAccessibilityService : AccessibilityService() {
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+        // 不需要处理任何无障碍事件
+    }
+
+    override fun onInterrupt() {}
+
+    override fun onServiceConnected() {
+        super.onServiceConnected()
+        Log.d("KeepAlive", "无障碍服务已连接，检查代理服务")
+        KeepAlive.tryRestart(this)
+    }
+}

--- a/android/app/src/main/kotlin/com/moi/lumine/keepalive/KeepAliveGuideScreen.kt
+++ b/android/app/src/main/kotlin/com/moi/lumine/keepalive/KeepAliveGuideScreen.kt
@@ -1,0 +1,457 @@
+package com.moi.lumine.keepalive
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoMode
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.moi.lumine.ui.theme.GreenConnect
+
+data class PermissionItem(
+    val title: String,
+    val description: String,
+    val isGranted: Boolean,
+    val actionLabel: String,
+    val onClick: () -> Unit
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun KeepAliveGuideScreen(
+    navController: NavController
+) {
+    val context = LocalContext.current
+    val manufacturer = Build.MANUFACTURER.lowercase()
+
+    val items = listOf(
+        PermissionItem(
+            title = "开启无障碍服务（核心）",
+            description = "手机设置 → 无障碍/辅助功能 → Lumine → 开启。\n划掉app后系统会自动重启此服务，1~3秒内恢复代理",
+            isGranted = isAccessibilityServiceEnabled(context),
+            actionLabel = "去设置",
+            onClick = { openAccessibilitySettings(context) }
+        ),
+        PermissionItem(
+            title = "允许自启动",
+            description = getAutoStartDescription(manufacturer),
+            isGranted = false,
+            actionLabel = "去设置",
+            onClick = { openAutoStartSettings(context, manufacturer) }
+        ),
+        PermissionItem(
+            title = "关闭电池优化",
+            description = "允许应用在后台不受电池优化限制，持续运行",
+            isGranted = isBatteryOptimizationDisabled(context),
+            actionLabel = "去设置",
+            onClick = { openBatteryOptimizationSettings(context) }
+        ),
+        PermissionItem(
+            title = "允许后台活动",
+            description = getBackgroundActivityDescription(manufacturer),
+            isGranted = false,
+            actionLabel = "去设置",
+            onClick = { openAppInfoSettings(context) }
+        ),
+        PermissionItem(
+            title = "锁定最近任务",
+            description = "在多任务界面长按应用卡片，点击锁定图标，防止被清理",
+            isGranted = false,
+            actionLabel = "知道了",
+            onClick = {}
+        ),
+        PermissionItem(
+            title = "通知权限",
+            description = "确保通知权限已开启，服务通知是保活的关键",
+            isGranted = false,
+            actionLabel = "去设置",
+            onClick = { openNotificationSettings(context) }
+        )
+    )
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("保活设置", fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.Filled.AutoMode,
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
+        ) {
+            // Warning card
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f)
+                ),
+                shape = MaterialTheme.shapes.large
+            ) {
+                Row(
+                    modifier = Modifier.padding(16.dp),
+                    verticalAlignment = Alignment.Top
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Warning,
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                        tint = MaterialTheme.colorScheme.error
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column {
+                        Text(
+                            text = "为什么需要这些设置？",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "ColorOS、MIUI等国产系统会在用户划掉应用时强制杀死进程，导致代理中断。\n\n" +
+                                    "开启以下权限后，应用才能在后台持续运行，保持代理连接和通知显示。",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            items.forEachIndexed { index, item ->
+                PermissionCardWithStep(
+                    stepNumber = index + 1,
+                    item = item
+                )
+                if (index < items.lastIndex) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun PermissionCardWithStep(
+    stepNumber: Int,
+    item: PermissionItem
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 2.dp
+        ),
+        shape = MaterialTheme.shapes.large
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            // Step indicator
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(CircleShape)
+                    .background(
+                        if (item.isGranted) GreenConnect
+                        else MaterialTheme.colorScheme.primaryContainer
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                if (item.isGranted) {
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = Color.White
+                    )
+                } else {
+                    Text(
+                        text = stepNumber.toString(),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = if (item.isGranted) Color.White
+                        else MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = item.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedButton(
+                    onClick = item.onClick,
+                    shape = MaterialTheme.shapes.small
+                ) {
+                    Text(
+                        text = item.actionLabel,
+                        style = MaterialTheme.typography.labelLarge
+                    )
+                }
+            }
+
+            // Status icon
+            if (item.isGranted) {
+                Icon(
+                    imageVector = Icons.Filled.CheckCircle,
+                    contentDescription = "已设置",
+                    tint = GreenConnect,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+    }
+}
+
+private fun isAutoStartEnabled(context: Context): Boolean {
+    return try {
+        val intent = Intent().apply {
+            component = ComponentName(
+                "com.coloros.safecenter",
+                "com.coloros.safecenter.permission.startup.StartupAppListActivity"
+            )
+        }
+        context.startActivity(intent)
+        true
+    } catch (_: Exception) {
+        try {
+            val intent = Intent().apply {
+                component = ComponentName(
+                    "com.miui.securitycenter",
+                    "com.miui.permcenter.autostart.AutoStartManagementActivity"
+                )
+            }
+            context.startActivity(intent)
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+}
+
+private fun getAutoStartDescription(manufacturer: String): String {
+    return when {
+        manufacturer.contains("oppo") || manufacturer.contains("coloros") ->
+            "设置 → 电池 → 自启动管理 → 开启 Lumine"
+        manufacturer.contains("xiaomi") || manufacturer.contains("miui") ->
+            "设置 → 应用设置 → 自启动管理 → 开启 Lumine"
+        manufacturer.contains("huawei") || manufacturer.contains("emui") ->
+            "设置 → 电池 → 启动管理 → 手动管理 → Lumine → 全部开启"
+        manufacturer.contains("vivo") || manufacturer.contains("funtouch") ->
+            "i管家 → 应用管理 → 权限管理 → 自启动 → 开启 Lumine"
+        else -> "确保应用可以在后台自动启动"
+    }
+}
+
+private fun openAutoStartSettings(context: Context, manufacturer: String) {
+    try {
+        val intent = when {
+            manufacturer.contains("oppo") || manufacturer.contains("coloros") -> {
+                Intent().apply {
+                    component = ComponentName(
+                        "com.coloros.safecenter",
+                        "com.coloros.safecenter.permission.startup.StartupAppListActivity"
+                    )
+                }
+            }
+            manufacturer.contains("xiaomi") || manufacturer.contains("miui") -> {
+                Intent().apply {
+                    component = ComponentName(
+                        "com.miui.securitycenter",
+                        "com.miui.permcenter.autostart.AutoStartManagementActivity"
+                    )
+                }
+            }
+            manufacturer.contains("huawei") || manufacturer.contains("emui") -> {
+                Intent().apply {
+                    component = ComponentName(
+                        "com.huawei.systemmanager",
+                        "com.huawei.systemmanager.startupmgr.ui.StartupNormalAppListActivity"
+                    )
+                }
+            }
+            manufacturer.contains("vivo") || manufacturer.contains("funtouch") -> {
+                Intent().apply {
+                    component = ComponentName(
+                        "com.iqoo.secure",
+                        "com.iqoo.secure.ui.phoneoptimize.AddWhiteListActivity"
+                    )
+                }
+            }
+            else -> {
+                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.parse("package:${context.packageName}")
+                }
+            }
+        }
+        context.startActivity(intent)
+    } catch (_: Exception) {
+        try {
+            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+            intent.data = Uri.parse("package:${context.packageName}")
+            context.startActivity(intent)
+        } catch (_: Exception) {}
+    }
+}
+
+private fun isBatteryOptimizationDisabled(context: Context): Boolean {
+    val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    return pm.isIgnoringBatteryOptimizations(context.packageName)
+}
+
+private fun openBatteryOptimizationSettings(context: Context) {
+    try {
+        val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+            data = Uri.parse("package:${context.packageName}")
+        }
+        context.startActivity(intent)
+    } catch (_: Exception) {
+        try {
+            val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+            context.startActivity(intent)
+        } catch (_: Exception) {}
+    }
+}
+
+private fun getBackgroundActivityDescription(manufacturer: String): String {
+    return when {
+        manufacturer.contains("oppo") || manufacturer.contains("coloros") ->
+            "设置 → 应用管理 → Lumine → 耗电管理 → 允许后台活动"
+        manufacturer.contains("xiaomi") || manufacturer.contains("miui") ->
+            "设置 → 应用设置 → 应用管理 → Lumine → 省电策略 → 无限制"
+        manufacturer.contains("huawei") || manufacturer.contains("emui") ->
+            "设置 → 电池 → 启动管理 → Lumine → 手动管理 → 后台活动开启"
+        manufacturer.contains("vivo") || manufacturer.contains("funtouch") ->
+            "i管家 → 应用管理 → 权限管理 → 后台活动 → 开启 Lumine"
+        else -> "确保应用可以在后台活动"
+    }
+}
+
+private fun openAppInfoSettings(context: Context) {
+    try {
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+        intent.data = Uri.parse("package:${context.packageName}")
+        context.startActivity(intent)
+    } catch (_: Exception) {}
+}
+
+private fun openNotificationSettings(context: Context) {
+    try {
+        val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+            putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+        }
+        context.startActivity(intent)
+    } catch (_: Exception) {
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+        intent.data = Uri.parse("package:${context.packageName}")
+        context.startActivity(intent)
+    }
+}
+
+private fun isAccessibilityServiceEnabled(context: Context): Boolean {
+    val serviceName = "${context.packageName}/com.moi.lumine.keepalive.KeepAliveAccessibilityService"
+    val enabledServices = Settings.Secure.getString(
+        context.contentResolver,
+        Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
+    ) ?: return false
+    return enabledServices.split(":").any { it.equals(serviceName, ignoreCase = true) }
+}
+
+private fun openAccessibilitySettings(context: Context) {
+    try {
+        val intent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
+        context.startActivity(intent)
+    } catch (_: Exception) {
+        try {
+            val intent = Intent().apply {
+                component = ComponentName(
+                    "com.coloros.safecenter",
+                    "com.coloros.safecenter无障碍.AccessibilityListActivity"
+                )
+            }
+            context.startActivity(intent)
+        } catch (_: Exception) {
+            try {
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                intent.data = Uri.parse("package:${context.packageName}")
+                context.startActivity(intent)
+            } catch (_: Exception) {}
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/moi/lumine/keepalive/KeepAliveJobService.kt
+++ b/android/app/src/main/kotlin/com/moi/lumine/keepalive/KeepAliveJobService.kt
@@ -1,0 +1,55 @@
+package com.moi.lumine.keepalive
+
+import android.app.job.JobInfo
+import android.app.job.JobParameters
+import android.app.job.JobScheduler
+import android.app.job.JobService
+import android.content.ComponentName
+import android.content.Context
+import android.util.Log
+
+class KeepAliveJobService : JobService() {
+
+    override fun onStartJob(params: JobParameters?): Boolean {
+        Log.d("KeepAliveJob", "JobScheduler 触发，检查服务状态")
+
+        if (!KeepAlive.shouldRun(this)) {
+            jobFinished(params, false)
+            return true
+        }
+
+        KeepAlive.tryRestart(this)
+        jobFinished(params, false)
+        return true
+    }
+
+    override fun onStopJob(params: JobParameters?): Boolean {
+        return false
+    }
+
+    companion object {
+        private const val JOB_ID = 10086
+
+        fun schedule(context: Context) {
+            val scheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+            if (scheduler.getPendingJob(JOB_ID) != null) return
+
+            if (!KeepAlive.shouldRun(context)) return
+
+            val jobInfo = JobInfo.Builder(JOB_ID, ComponentName(context, KeepAliveJobService::class.java))
+                .setPeriodic(15 * 60 * 1000L)
+                .setPersisted(true)
+                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                .build()
+
+            val result = scheduler.schedule(jobInfo)
+            Log.d("KeepAliveJob", "JobScheduler 调度: ${if (result == JobScheduler.RESULT_SUCCESS) "成功" else "失败"}")
+        }
+
+        fun cancel(context: Context) {
+            val scheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+            scheduler.cancel(JOB_ID)
+            Log.d("KeepAliveJob", "JobScheduler 已取消")
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/moi/lumine/keepalive/ServiceRestartReceiver.kt
+++ b/android/app/src/main/kotlin/com/moi/lumine/keepalive/ServiceRestartReceiver.kt
@@ -1,0 +1,62 @@
+package com.moi.lumine.keepalive
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.SystemClock
+import com.moi.lumine.MainActivity
+
+class ServiceRestartReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        // 未开启代理 → 取消全部保活调度
+        if (!KeepAlive.shouldRun(context)) {
+            KeepAlive.cancelAll(context)
+            return
+        }
+
+        KeepAlive.tryRestart(context)
+
+        // 设下一次闹钟（链），15 秒后再次检查
+        KeepAlive.scheduleAll(context)
+    }
+
+    companion object {
+        private const val REQUEST_CODE = 9999
+
+        fun scheduleAlarm(context: Context) {
+            try {
+                val restartIntent = Intent(context, ServiceRestartReceiver::class.java)
+                val pendingIntent = PendingIntent.getBroadcast(
+                    context, REQUEST_CODE, restartIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+                val triggerTime = SystemClock.elapsedRealtime() + 10_000L
+
+                // showIntent 必须指向 Activity，否则部分厂商不触发
+                val showIntent = Intent(context, MainActivity::class.java)
+                val showPending = PendingIntent.getActivity(
+                    context, REQUEST_CODE + 1, showIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                val alarmInfo = AlarmManager.AlarmClockInfo(triggerTime, showPending)
+                alarmManager.setAlarmClock(alarmInfo, pendingIntent)
+            } catch (_: Exception) {}
+        }
+
+        fun cancelAlarm(context: Context) {
+            try {
+                val restartIntent = Intent(context, ServiceRestartReceiver::class.java)
+                val pendingIntent = PendingIntent.getBroadcast(
+                    context, REQUEST_CODE, restartIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+                alarmManager.cancel(pendingIntent)
+            } catch (_: Exception) {}
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/moi/lumine/keepalive/ServiceWatchdogWorker.kt
+++ b/android/app/src/main/kotlin/com/moi/lumine/keepalive/ServiceWatchdogWorker.kt
@@ -1,0 +1,47 @@
+package com.moi.lumine.keepalive
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import java.util.concurrent.TimeUnit
+
+class ServiceWatchdogWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        // 未开启代理 → 不需要保活，取消自身
+        if (!KeepAlive.shouldRun(applicationContext)) {
+            cancel(applicationContext)
+            return Result.success()
+        }
+
+        KeepAlive.tryRestart(applicationContext)
+        return Result.success()
+    }
+
+    companion object {
+        private const val WORK_NAME = "service_watchdog"
+
+        fun schedule(context: Context) {
+            val request = PeriodicWorkRequestBuilder<ServiceWatchdogWorker>(
+                15, TimeUnit.MINUTES
+            ).setInitialDelay(1, TimeUnit.MINUTES)
+                .build()
+
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                request
+            )
+        }
+
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/moi/lumine/ui/Screen.kt
+++ b/android/app/src/main/kotlin/com/moi/lumine/ui/Screen.kt
@@ -9,4 +9,5 @@ sealed class Screen(val route: String) {
     }
     object Settings : Screen("settings")
     object Logs : Screen("logs")
+    object KeepAlive : Screen("keepalive")
 }

--- a/android/app/src/main/kotlin/com/moi/lumine/ui/screens/HomeScreen.kt
+++ b/android/app/src/main/kotlin/com/moi/lumine/ui/screens/HomeScreen.kt
@@ -88,6 +88,7 @@ fun HomeScreen(
 
         item { MenuItem(Icons.Default.Tune, "规则") { navController.navigate(Screen.Rules.route) } }
         item { MenuItem(Icons.AutoMirrored.Filled.Assignment, "日志") { navController.navigate(Screen.Logs.route) } }
+        item { MenuItem(Icons.Default.Security, "保活设置") { navController.navigate(Screen.KeepAlive.route) } }
         item { MenuItem(Icons.Default.Settings, "设置") { navController.navigate(Screen.Settings.route) } }
         item {
             MenuItem(Icons.Default.Info, "关于") {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_service_description">保持 Lumine 代理服务在后台持续运行。开启后，即使从最近任务中划掉应用，代理也会自动恢复。</string>
+</resources>

--- a/android/app/src/main/res/xml/accessibility_service_config.xml
+++ b/android/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeAllMask"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagDefault"
+    android:canPerformGestures="false"
+    android:canRetrieveWindowContent="false"
+    android:notificationTimeout="100"
+    android:settingsActivity="com.moi.lumine.MainActivity"
+    android:description="@string/accessibility_service_description" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     ext.kotlin_version = "1.9.23"
     repositories {
+        maven { url 'https://maven.aliyun.com/repository/google' }
+        maven { url 'https://maven.aliyun.com/repository/central' }
+        maven { url 'https://maven.aliyun.com/repository/public' }
+        maven { url 'https://maven.aliyun.com/repository/gradle-plugin' }
         google()
         mavenCentral()
     }
@@ -12,6 +16,9 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { url 'https://maven.aliyun.com/repository/google' }
+        maven { url 'https://maven.aliyun.com/repository/central' }
+        maven { url 'https://maven.aliyun.com/repository/public' }
         google()
         mavenCentral()
         flatDir {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://mirrors.cloud.tencent.com/gradle/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# 保活移植修改记录

## 新增文件（com.moi.lumine.keepalive）

- **KeepAlive.kt**：公共入口。shouldRun/tryRestart/scheduleAll/cancelAll，状态依据 ConfigRepository.shouldVpnBeRunning()
- **KeepAliveAccessibilityService.kt**：无障碍服务，onServiceConnected → tryRestart
- **KeepAliveJobService.kt**：JobScheduler 15 分钟兜底（ID 10086）
- **ServiceRestartReceiver.kt**：AlarmManager 闹钟链 10s/15s（AlarmClockInfo，CODE 9999）
- **ServiceWatchdogWorker.kt**：WorkManager 15 分钟兜底
- **BootReceiver.kt**：BOOT_COMPLETED / MY_PACKAGE_REPLACED 恢复
- **KeepAliveGuideScreen.kt**：引导页（自启动/后台活动/电池优化/无障碍/通知，含各 ROM 路径）
- **LumineApp.kt**：Application，开启才 scheduleAll + 10s watchdog
- res/xml/accessibility_service_config.xml、res/values/strings.xml

## 修改文件

**LumineVpnService.kt**

- isServiceRunning 标志 + EXTRA_REQUEST_VPN_PERMISSION
- recover 分支（:63）：prepare()!=null → startForeground("等待 VPN 授权") → 拉起 MainActivity 重新请求授权
- onTaskRemoved（:271）：划掉后台完全停止（停核心+移除通知+stopSelf）+ 排闹钟保活拉起
- fdsan 修复（:392）：closePendingTunFd 仅 Go 未接管时 close；startLumine 失败路径不再 close → 消除双重关闭 SIGABRT

**AndroidManifest.xml**

- FGS 类型 systemExempted → specialUse（+ FOREGROUND_SERVICE_SPECIAL_USE 权限 + property）
- 新增权限 RECEIVE_BOOT_COMPLETED / POST_NOTIFICATIONS / REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
- application 加 .LumineApp；声明 4 个保活组件

**MainActivity.kt**：autoRecover——打开时 shouldRun 且服务没跑 → 自动恢复；授权失效弹框重请求

**HomeScreen.kt / Screen.kt**：加"保活设置"入口

**build.gradle**：+ work-runtime-ktx:2.9.0；仓库改阿里云镜像+官方兜底

**gradle-wrapper.properties**：distributionUrl → 腾讯镜像