### PR TITLE
fix: move pluginManagement block to the top of settings.gradle

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,6 +1,4 @@
 // android/settings.gradle
-rootProject.name = "LumineAndroid"
-
 pluginManagement {
     repositories {
         // 优先使用腾讯云镜像以提高国内 CI/Runner 的依赖可用性
@@ -31,4 +29,5 @@ dependencyResolutionManagement {
     }
 }
 
+rootProject.name = "LumineAndroid"
 include ':app'


### PR DESCRIPTION
## 问题

CI 构建在 "Build APKs" 步骤失败，错误信息：

```
Could not compile settings file '.../android/settings.gradle'.
> startup failed:
  settings file '.../android/settings.gradle': 4: The pluginManagement {} block must appear before any other statements in the script.
```

## 根因

PR #36 在 `settings.gradle` 中添加了 `pluginManagement {}` 和 `dependencyResolutionManagement {}` 块，但将 `rootProject.name = "LumineAndroid"` 放在了 `pluginManagement {}` 之前。根据 Gradle 规则，`pluginManagement {}` 块必须出现在脚本中的任何其他语句之前。

## 修复

将 `rootProject.name = "LumineAndroid"` 移到 `dependencyResolutionManagement {}` 块之后，恢复正确的 Gradle settings 文件结构顺序：

1. `pluginManagement {}`
2. `dependencyResolutionManagement {}`
3. `rootProject.name` / `include`

## 验证

本地完整复现了 CI 构建流程：
- ✅ 安装 Android SDK (platform-tools, platforms;android-36, build-tools;36.0.0, ndk;30.0.14904198)
- ✅ 安装 gomobile 并构建 `LumineCore.aar`
- ✅ `./gradlew assembleRelease` 成功编译 `settings.gradle` 并生成所有 4 个 ABI 的 release APK（未签名）

修复前 `./gradlew help` 即因 settings.gradle 编译失败而退出；修复后构建顺利完成。